### PR TITLE
[EPO-1922] Results page presents QAs: minimal styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,12 +14,7 @@ import Histogram from './components/histogram';
 
 @reactn
 class App extends Component {
-  // constructor(props) {
-  //   super(props);
-  //   this.state = {};
-  // }
-
-  handleStateTestClick = () => {
+  updateLocalStorage() {
     const { answers } = this.global;
     this.setGlobal(
       prevState => ({
@@ -31,6 +26,10 @@ class App extends Component {
         ls('hrd', this.global);
       }
     );
+  }
+
+  handleStateTestClick = () => {
+    this.updateLocalStorage();
   };
 
   handleClearLocalStorage = () => {

--- a/src/assets/stylesheets/STACSS/_structure.scss
+++ b/src/assets/stylesheets/STACSS/_structure.scss
@@ -21,6 +21,15 @@
   margin: 0 auto;
 }
 
+.container-page {
+  .scrollable {
+    max-height: calc(100vh - 64px - 2 * #{$minPadding});
+    // This feels wroooong
+    overflow-x: hidden;
+    overflow-y: scroll;
+  }
+}
+
 .container-flex, .md-card.container-flex, .md-card-text.container-flex,  {
   display: flex;
 

--- a/src/assets/stylesheets/components/content/_index.scss
+++ b/src/assets/stylesheets/components/content/_index.scss
@@ -1,2 +1,3 @@
 @import 'qas';
+@import 'results';
 @import 'section';

--- a/src/assets/stylesheets/components/content/_results.scss
+++ b/src/assets/stylesheets/components/content/_results.scss
@@ -1,0 +1,22 @@
+.results {
+  @include listUnstyled;
+
+  .result {
+    + .result {
+      margin-top: $minPadding;
+    }
+
+    .question {
+      @include subheadingPrimary;
+      font-weight: $medium;
+    }
+
+    .answer {
+      margin-left: $minPadding;
+    }
+
+    .answer-content, .unit {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/components/content/sections/ExploringStarClusters.jsx
+++ b/src/components/content/sections/ExploringStarClusters.jsx
@@ -57,7 +57,7 @@ class ExploringStarClusters extends React.PureComponent {
     const { answers: prevAnswers } = this.global;
     const prevAnswer = { ...prevAnswers[id] };
     const content = answerAccessor ? data[answerAccessor] : data;
-
+    console.log('globaling', this);
     this.setGlobal(prevGlobal => ({
       ...prevGlobal,
       answers: {
@@ -143,6 +143,11 @@ class ExploringStarClusters extends React.PureComponent {
             brightness—are the product of the star’s initial mass and this clash
             of forces, and these physical properties change during a star’s
             lifetime.
+          </p>
+          <p>
+            The main sequence forms a slightly s-shaped diagonal band across the
+            plot. To determine the approximate position of the main sequence
+            stars on an H-R Diagram, complete the following:
           </p>
           <hr className="divider-horizontal" />
           {questions && (

--- a/src/components/content/sections/Results.jsx
+++ b/src/components/content/sections/Results.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Route, Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import range from 'lodash/range';
+import isEmpty from 'lodash/isEmpty';
+import Button from 'react-md/lib/Buttons/Button';
+import Page from '../../site/Page';
+
+class Results extends React.PureComponent {
+  static defaultProps = {
+    next: '',
+    nextText: 'Finish',
+    order: range(1, 6),
+  };
+
+  renderAccordionQA(index, question, answer) {
+    const { answerPre: pre, answerAccessor: accessor, label } = question;
+    const count = index + 1;
+
+    return (
+      <div className="qa">
+        <div className="question">
+          <span>{count}. </span>
+          {label}
+        </div>
+        {!isEmpty(answer) ? (
+          <p className="answer">
+            {pre && <span className="answer-pre">{pre} </span>}
+            <span className="answer-content">{answer.content}</span>
+            {accessor === 'teff' && <span className="unit"> K</span>}
+            {accessor === 'luminosity' && <sub className="unit">&#8857;</sub>}
+          </p>
+        ) : (
+          <p className="answer">No answer provided</p>
+        )}
+      </div>
+    );
+  }
+
+  renderQA(index, question, answer) {
+    const { type } = question;
+
+    if (type === 'accordion') {
+      return this.renderAccordionQA(index, question, answer);
+    }
+
+    return (
+      <div className="qa">
+        <div className="question">{JSON.strigify(question)}</div>
+        {!isEmpty(answer) ? (
+          <p className="answer">{JSON.stringify(answer)}</p>
+        ) : (
+          <p className="answer">No answer provided</p>
+        )}
+      </div>
+    );
+  }
+
+  renderQAs(order, questions, answers) {
+    return (
+      <ul className="results qas">
+        {order.map((id, index) => {
+          const question = questions[id];
+          const answer = answers[id];
+
+          return (
+            <li key={`qa-${id}`} className="result">
+              {this.renderQA(index, question, answer)}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  render() {
+    const {
+      id,
+      next,
+      nextText,
+      questions = {},
+      answers = {},
+      order,
+      handleFinish,
+    } = this.props;
+
+    return (
+      <Route
+        exact
+        path={`/${id}`}
+        render={routeProps => (
+          <Page {...routeProps}>
+            <section>
+              <h1 className="section-title">Results</h1>
+              {questions &&
+                answers &&
+                this.renderQAs(order, questions, answers)}
+            </section>
+            <nav role="navigation" className="nav-secondary">
+              <Button
+                flat
+                primary
+                swapTheming
+                to={next}
+                component={Link}
+                onClick={handleFinish}
+              >
+                {nextText}
+              </Button>
+            </nav>
+          </Page>
+        )}
+      />
+    );
+  }
+}
+
+Results.propTypes = {
+  id: PropTypes.number,
+  questions: PropTypes.object,
+  answers: PropTypes.object,
+  next: PropTypes.string,
+  nextText: PropTypes.string,
+  order: PropTypes.array,
+  handleFinish: PropTypes.func,
+};
+
+export default Results;

--- a/src/components/content/sections/Section.jsx
+++ b/src/components/content/sections/Section.jsx
@@ -12,7 +12,16 @@ class Section extends React.PureComponent {
   };
 
   render() {
-    const { children, id, layout, dividers, paginationLocation } = this.props;
+    const {
+      children,
+      id,
+      layout,
+      dividers,
+      paginationLocation,
+      next,
+      nextHandler,
+    } = this.props;
+
     return (
       <Route
         exact
@@ -20,8 +29,9 @@ class Section extends React.PureComponent {
         render={routeProps => (
           <Page
             {...routeProps}
-            next={`/${id + 1}`}
+            next={next || `/${id + 1}`}
             nextText="Continue"
+            nextHandler={nextHandler}
             layout={layout}
             dividers={dividers}
             paginationLocation={paginationLocation}
@@ -40,6 +50,8 @@ Section.propTypes = {
   layout: PropTypes.string,
   dividers: PropTypes.bool,
   paginationLocation: PropTypes.number,
+  next: PropTypes.string,
+  nextHandler: PropTypes.func,
 };
 
 export default Section;

--- a/src/components/content/sections/index.jsx
+++ b/src/components/content/sections/index.jsx
@@ -6,39 +6,37 @@ import range from 'lodash/range';
 import API from '../../site/API';
 import Introduction from './Introduction';
 import ExploringStarClusters from './ExploringStarClusters';
+import Results from './Results';
 
 @reactn
 class Sections extends React.PureComponent {
-  constructor(props) {
-    super(props);
+  // constructor(props) {
+  //   super(props);
+  // }
 
-    this.state = {
-      loading: true,
-    };
-
-    API.get('static-data/questions.json').then(res => {
-      this.setGlobal(
-        prevGlobal => ({
+  componentDidMount() {
+    if (isEmpty(this.global.questions)) {
+      API.get('static-data/questions.json').then(res => {
+        this.setGlobal(prevGlobal => ({
           ...prevGlobal,
           questions: res.data,
-        }),
-        this.setState({
-          loading: false,
-        })
-      );
-    });
-  }
-
-  getQuestion(id) {
-    if (!isEmpty(this.global.questions)) {
-      return this.global.questions[id];
+        }));
+      });
     }
-
-    return null;
   }
+
+  onFinish = () => {
+    console.log('finishing');
+    this.dispatch.empty();
+  };
+
+  // onSectionChange = () => {
+  //   this.dispatch.updateLS();
+  // };
 
   getQuestions(questionsRange) {
     const { questions } = this.global;
+
     if (!isEmpty(questions)) {
       return questionsRange.map(questionId => {
         return questions[questionId.toString()];
@@ -49,19 +47,27 @@ class Sections extends React.PureComponent {
   }
 
   render() {
-    const { activeId } = this.global;
-    const { loading } = this.state;
+    const { activeId, questions, answers } = this.global;
+    const loading = isEmpty(questions);
 
     return (
       <React.Fragment>
         {!loading ? (
           <React.Fragment>
-            <Introduction />
+            <Introduction next="1" />
             <ExploringStarClusters
-              id={1}
+              id="1"
               questionsRange={range(1, 7)}
               questions={this.getQuestions(range(1, 7))}
               activeId={activeId}
+              next="100"
+              scrollable={0}
+            />
+            <Results
+              id="100"
+              questions={questions}
+              answers={answers}
+              handleFinish={this.onFinish}
             />
           </React.Fragment>
         ) : (

--- a/src/components/questions/ExpansionPanel.jsx
+++ b/src/components/questions/ExpansionPanel.jsx
@@ -20,11 +20,9 @@ class QuestionExpansionPanel extends React.PureComponent {
     } = this.props;
     const { answerPre, answerAccessor, id: qId } = question;
 
-    const answerIsBlank = isEmpty(answer);
-    const answered = answer && !answerIsBlank;
+    const answered = !isEmpty(answer);
     const isExpanded = active || answered;
-    const showFooter =
-      answerIsBlank || (!active && answered) ? null : undefined;
+    const showFooter = !answered || (!active && answered) ? null : undefined;
 
     const questionClasses = classnames('qa no-pointer', {
       active,

--- a/src/components/site/Page.jsx
+++ b/src/components/site/Page.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Button from 'react-md/lib/Buttons/Button';
 import ArrowLeft from './icons/ArrowLeft';
 import ArrowRight from './icons/ArrowRight';
@@ -9,17 +10,51 @@ class Page extends React.PureComponent {
   static defaultProps = {
     previousText: 'Previous',
     nextText: 'Next',
-    scrollable: -1,
+    scrollable: 0,
   };
+
+  renderNav() {
+    const { previous, previousText, next, nextText, nextHandler } = this.props;
+
+    return (
+      <nav role="navigation" className="nav-secondary">
+        {previous && (
+          <Button
+            flat
+            primary
+            swapTheming
+            to={previous}
+            component={Link}
+            iconEl={<ArrowLeft />}
+            iconBefore={false}
+          >
+            {previousText}
+          </Button>
+        )}
+        {next && (
+          <Button
+            flat
+            primary
+            swapTheming
+            to={next}
+            component={Link}
+            iconEl={<ArrowRight />}
+            iconBefore={false}
+            onClick={nextHandler}
+          >
+            {nextText}
+          </Button>
+        )}
+      </nav>
+    );
+  }
 
   render() {
     const {
       children,
       dividers,
       previous,
-      previousText,
       next,
-      nextText,
       layout,
       paginationLocation,
       scrollable,
@@ -32,54 +67,32 @@ class Page extends React.PureComponent {
             {React.Children.map(children, (child, i) => {
               const length = React.Children.count(children);
               const colWidth = Math.floor(100 / length);
+              const colClasses = classnames(
+                `col padded col-${i + 1}`,
+                `col-width-${colWidth}`,
+                {
+                  scrollable: scrollable === i,
+                }
+              );
+
               return (
                 <React.Fragment>
                   {dividers && i !== 0 && <div className="divider-vertical" />}
-                  <div
-                    className={`
-                      col padded col-${i + 1}
-                      col-width-${colWidth}
-                      ${scrollable === i ? 'scrollable' : ''}
-                    `}
-                  >
+                  <div className={colClasses}>
                     {child}
-                    {paginationLocation === i + 1 && (
-                      <nav role="navigation" className="nav-secondary">
-                        {previous && (
-                          <Button
-                            flat
-                            primary
-                            swapTheming
-                            to={previous}
-                            component={Link}
-                            iconEl={<ArrowLeft />}
-                            iconBefore={false}
-                          >
-                            {previousText}
-                          </Button>
-                        )}
-                        {next && (
-                          <Button
-                            flat
-                            primary
-                            swapTheming
-                            to={next}
-                            component={Link}
-                            iconEl={<ArrowRight />}
-                            iconBefore={false}
-                          >
-                            {nextText}
-                          </Button>
-                        )}
-                      </nav>
-                    )}
+                    {paginationLocation === i + 1 && this.renderNav()}
                   </div>
                 </React.Fragment>
               );
             })}
           </div>
         )}
-        {!layout && children}
+        {!layout && (
+          <React.Fragment>
+            {children}
+            {(next || previous) && this.renderNav()}
+          </React.Fragment>
+        )}
       </div>
     );
   }
@@ -92,10 +105,10 @@ Page.propTypes = {
   previousText: PropTypes.string,
   next: PropTypes.string,
   nextText: PropTypes.string,
+  nextHandler: PropTypes.func,
   layout: PropTypes.string,
   paginationLocation: PropTypes.number,
   scrollable: PropTypes.number,
-  // colClasses: PropTypes.string,
 };
 
 export default Page;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-import React, { setGlobal } from 'reactn';
+import React, { addCallback, addReducer, setGlobal } from 'reactn';
 import ReactDOM from 'react-dom';
 import ls from 'local-storage';
 import App from './App.jsx';
@@ -14,7 +14,32 @@ const emptyState = {
 };
 
 const existingState = ls('hrd') || emptyState;
+
 setGlobal(existingState);
+
+// Maybe a bit heavy handed?  Better to tie this LocalStorage Update to the route/section changes...?
+addCallback(global => {
+  ls('hrd', global);
+  return null;
+});
+
+// addReducer('updateLS', global => {
+//   ls('hrd', global);
+// });
+
+addReducer('empty', prevGlobal => {
+  console.log('emptying');
+  const global = {
+    ...prevGlobal,
+    answers: {},
+    activeId: null,
+    activeGraphData: null,
+  };
+
+  ls('hrd', global);
+
+  return global;
+});
 
 if (process.env.NODE_ENV !== 'production') {
   const Axe = require('react-axe'); // eslint-disable-line global-require


### PR DESCRIPTION
Uses localStorage questions obj for global state: API request fallback
Global State syncs to Local Storage whenever there's a change
Reset answers obj in state and localStorage when click finish button on results page
Includes only styles, logic, and markup for currently used QA types
Left column in two column Page layout is fixed height (~100vh) and scrollable in Y direction (locked in X direction to prevent addition of scrollbar)