### PR TITLE
Store and compare user graphs/star-cluster-selections with astronomer's graphs/star-cluster-selections

### DIFF
--- a/src/assets/stylesheets/components/content/_results.scss
+++ b/src/assets/stylesheets/components/content/_results.scss
@@ -13,6 +13,10 @@
 
     .answer {
       margin-left: $minPadding;
+
+      &.graph {
+        max-width: 320px;
+      }
     }
 
     .answer-content, .unit {

--- a/src/components/content/sections/ComparingHRD.jsx
+++ b/src/components/content/sections/ComparingHRD.jsx
@@ -5,49 +5,34 @@ import API from '../../site/API';
 import Section from './Section';
 import ScatterPlot from '../../scatter-plot';
 import StarSelector from '../../star-selector';
-import ClusterImage from '../../../assets/images/star-clusters.jpg';
+import ClusterImage from '../../../assets/images/ngc188_FINAL.jpg';
 
 @reactn
-class MakingHRD extends React.PureComponent {
+class ComparingHRD extends React.PureComponent {
   constructor(props) {
     super(props);
 
     this.state = {
-      selection: [],
       clusterData: [],
     };
   }
 
   componentDidMount() {
-    API.get('static-data/stars.json').then(res => {
+    const { dataPath } = this.props;
+
+    API.get(dataPath).then(res => {
       this.setState(prevState => ({
         ...prevState,
-        clusterData: res.data,
+        clusterData: res.data.stars,
       }));
     });
   }
 
-  onGraphLasso = selectedData => {
-    this.setState(prevState => ({
-      ...prevState,
-      selection: selectedData,
-    }));
-  };
-
-  onGraphSelection = selectedData => {
-    this.setState(prevState => ({
-      ...prevState,
-      selection: selectedData,
-    }));
-  };
-
   render() {
     const { clusterData } = this.state;
-    let { selection } = this.state;
-
-    if (selection && !Array.isArray(selection)) {
-      selection = [selection];
-    }
+    const { activeId } = this.props;
+    const answer = this.global.answers[activeId];
+    const selection = answer ? answer.data : [];
 
     return (
       <Section {...this.props}>
@@ -57,12 +42,15 @@ class MakingHRD extends React.PureComponent {
           <StarSelector
             width={600}
             height={600}
-            data={clusterData}
-            xValueAccessor="temperature"
-            yValueAccessor="luminosity"
+            data={selection}
+            xValueAccessor="RA"
+            yValueAccessor="Dec"
+            xDomain={[16.160474211844242, 9.616988842401822]}
+            yDomain={[84.99507547492594, 85.53437634262413]}
             dataLassoCallback={this.onGraphLasso}
             dataSelectionCallback={this.onGraphSelection}
             backgroundImage={ClusterImage}
+            preSelected
           />
           <br />
           <h2>Your H-R Diagram</h2>
@@ -72,6 +60,7 @@ class MakingHRD extends React.PureComponent {
             yValueAccessor="luminosity"
             xAxisLabel="Temperature (K)"
             yAxisLabel="Solar Luminosity"
+            preSelected
           />
         </div>
         <div>
@@ -81,20 +70,26 @@ class MakingHRD extends React.PureComponent {
             width={600}
             height={600}
             data={clusterData}
-            xValueAccessor="temperature"
-            yValueAccessor="luminosity"
+            xValueAccessor="RA"
+            yValueAccessor="Dec"
+            xDomain={[16.160474211844242, 9.616988842401822]}
+            yDomain={[84.99507547492594, 85.53437634262413]}
             dataLassoCallback={this.onGraphLasso}
             dataSelectionCallback={this.onGraphSelection}
             backgroundImage={ClusterImage}
+            filterBy="is_member"
+            preSelected
           />
           <br />
           <h2>Astronomer&apos;s H-R Diagram</h2>
           <ScatterPlot
-            data={selection}
+            data={clusterData}
             xValueAccessor="temperature"
             yValueAccessor="luminosity"
             xAxisLabel="Temperature (K)"
             yAxisLabel="Solar Luminosity"
+            filterBy="is_member"
+            preSelected
           />
         </div>
       </Section>
@@ -102,7 +97,7 @@ class MakingHRD extends React.PureComponent {
   }
 }
 
-MakingHRD.propTypes = {
+ComparingHRD.propTypes = {
   id: PropTypes.number,
   layout: PropTypes.string,
   dividers: PropTypes.bool,
@@ -110,6 +105,7 @@ MakingHRD.propTypes = {
   questionsRange: PropTypes.array,
   questions: PropTypes.array,
   activeId: PropTypes.string,
+  dataPath: PropTypes.string,
 };
 
-export default MakingHRD;
+export default ComparingHRD;

--- a/src/components/content/sections/ExploringStarClusters.jsx
+++ b/src/components/content/sections/ExploringStarClusters.jsx
@@ -19,7 +19,9 @@ class ExploringStarClusters extends React.PureComponent {
   }
 
   componentDidMount() {
-    API.get('static-data/NGC_188_data.json').then(res => {
+    const { dataPath } = this.props;
+
+    API.get(dataPath).then(res => {
       this.setState(prevState => ({
         ...prevState,
         clusterData: res.data.stars,
@@ -193,6 +195,7 @@ class ExploringStarClusters extends React.PureComponent {
             yAxisLabel="Solar Luminosity"
             dataSelectionCallback={this.onGraphSelection}
             clearOnChange={isEmpty(activeAnswer)}
+            filterBy="is_member"
           />
         </div>
       </Section>
@@ -208,6 +211,7 @@ ExploringStarClusters.propTypes = {
   questionsRange: PropTypes.array,
   questions: PropTypes.array,
   activeId: PropTypes.string,
+  dataPath: PropTypes.string,
 };
 
 export default ExploringStarClusters;

--- a/src/components/content/sections/MakingHRD.jsx
+++ b/src/components/content/sections/MakingHRD.jsx
@@ -5,7 +5,8 @@ import API from '../../site/API';
 import Section from './Section';
 import ScatterPlot from '../../scatter-plot';
 import StarSelector from '../../star-selector';
-import ClusterImage from '../../../assets/images/star-clusters.jpg';
+import QuestionPrompts from '../../questions/prompts';
+import ClusterImage from '../../../assets/images/ngc188_FINAL.jpg';
 
 @reactn
 class MakingHRD extends React.PureComponent {
@@ -13,13 +14,14 @@ class MakingHRD extends React.PureComponent {
     super(props);
 
     this.state = {
-      selection: [],
       clusterData: [],
     };
   }
 
   componentDidMount() {
-    API.get('static-data/NGC_188_data.json').then(res => {
+    const { dataPath } = this.props;
+
+    API.get(dataPath).then(res => {
       this.setState(prevState => ({
         ...prevState,
         clusterData: res.data.stars,
@@ -27,27 +29,50 @@ class MakingHRD extends React.PureComponent {
     });
   }
 
-  onGraphLasso = selectedData => {
-    this.setState(prevState => ({
-      ...prevState,
-      selection: selectedData,
+  updateAnswer(id, data) {
+    const { answers: prevAnswers } = this.global;
+    const prevAnswer = { ...prevAnswers[id] };
+
+    this.setGlobal(prevGlobal => ({
+      ...prevGlobal,
+      answers: {
+        ...prevAnswers,
+        [id]: {
+          ...prevAnswer,
+          id,
+          data,
+        },
+      },
     }));
+  }
+
+  // componentDidUpdate() {
+  //   console.log(this.state.selection);
+  // }
+
+  onGraphLasso = selectedData => {
+    const { activeId } = this.props;
+
+    this.updateAnswer(activeId, selectedData);
   };
 
-  onGraphSelection = selectedData => {
-    this.setState(prevState => ({
-      ...prevState,
-      selection: selectedData,
-    }));
-  };
+  // onGraphSelection = selectedData => {
+  //   const { activeId } = this.props;
+  //   this.setGlobal(prevGlobal => ({
+  //     ...prevGlobal,
+  //     [activeId]: selectedData,
+  //   }));
+  // };
 
   render() {
     const { clusterData } = this.state;
-    let { selection } = this.state;
-
-    if (selection && !Array.isArray(selection)) {
-      selection = [selection];
-    }
+    const { activeId, questions } = this.props;
+    const answer = this.global.answers[activeId];
+    const selection = answer ? answer.data : [];
+    console.log(selection);
+    // if (selection && !Array.isArray(selection)) {
+    //   selection = [selection];
+    // }
 
     return (
       <Section {...this.props}>
@@ -86,20 +111,19 @@ class MakingHRD extends React.PureComponent {
             H-R Diagram for your cluster.
           </p>  */}
           <hr className="divider-horizontal" />
-          <p>
-            Draw circles around different groups of stars to plot them on the
-            H-R Diagram.
-          </p>
+          <QuestionPrompts questions={questions} />
           <br />
           <StarSelector
             width={600}
             height={600}
             data={clusterData}
-            xValueAccessor="Dec"
-            yValueAccessor="RA"
+            xValueAccessor="RA"
+            yValueAccessor="Dec"
+            xDomain={[16.160474211844242, 9.616988842401822]}
+            yDomain={[84.99507547492594, 85.53437634262413]}
             dataLassoCallback={this.onGraphLasso}
-            dataSelectionCallback={this.onGraphSelection}
             backgroundImage={ClusterImage}
+            selection={selection}
           />
         </section>
         <div className="col-graph">
@@ -125,6 +149,7 @@ MakingHRD.propTypes = {
   questionsRange: PropTypes.array,
   questions: PropTypes.array,
   activeId: PropTypes.string,
+  dataPath: PropTypes.string,
 };
 
 export default MakingHRD;

--- a/src/components/content/sections/Results.jsx
+++ b/src/components/content/sections/Results.jsx
@@ -5,14 +5,15 @@ import range from 'lodash/range';
 import isEmpty from 'lodash/isEmpty';
 import Button from 'react-md/lib/Buttons/Button';
 import Page from '../../site/Page';
+import ScatterPlot from '../../scatter-plot';
 import ArrowLeft from '../../site/icons/ArrowLeft';
 
 class Results extends React.PureComponent {
   static defaultProps = {
-    next: '1',
+    next: '/',
     nextText: 'Finish',
     previousText: 'Back',
-    order: range(1, 6),
+    order: range(1, 14),
   };
 
   renderAccordionQA(index, question, answer) {
@@ -39,6 +40,34 @@ class Results extends React.PureComponent {
     );
   }
 
+  renderPromptQA(index, question, answer) {
+    const { answerPre: pre } = question;
+    const count = index + 1;
+
+    return (
+      <div className="qa">
+        <div className="question">
+          <span>{count}. </span>
+          {pre}
+        </div>
+        {!isEmpty(answer) ? (
+          <div className="answer graph">
+            <ScatterPlot
+              data={answer.data}
+              xValueAccessor="temperature"
+              yValueAccessor="luminosity"
+              xAxisLabel="Temperature (K)"
+              yAxisLabel="Solar Luminosity"
+              preSelected
+            />
+          </div>
+        ) : (
+          <p className="answer">No answer provided</p>
+        )}
+      </div>
+    );
+  }
+
   renderQA(index, question, answer) {
     const { type } = question;
 
@@ -46,9 +75,13 @@ class Results extends React.PureComponent {
       return this.renderAccordionQA(index, question, answer);
     }
 
+    if (type === 'prompt') {
+      return this.renderPromptQA(index, question, answer);
+    }
+
     return (
       <div className="qa">
-        <div className="question">{JSON.strigify(question)}</div>
+        <div className="question">{JSON.stringify(question)}</div>
         {!isEmpty(answer) ? (
           <p className="answer">{JSON.stringify(answer)}</p>
         ) : (

--- a/src/components/content/sections/Section.jsx
+++ b/src/components/content/sections/Section.jsx
@@ -5,7 +5,7 @@ import Page from '../../site/Page';
 
 class Section extends React.PureComponent {
   static defaultProps = {
-    id: '',
+    id: '0',
     layout: 'two-col',
     dividers: false,
     paginationLocation: 1,
@@ -27,7 +27,7 @@ class Section extends React.PureComponent {
     return (
       <Route
         exact
-        path={`/${id}`}
+        path={id === '0' ? '/' : `/${id}`}
         render={routeProps => (
           <Page
             {...routeProps}

--- a/src/components/content/sections/index.jsx
+++ b/src/components/content/sections/index.jsx
@@ -63,10 +63,23 @@ class Sections extends React.PureComponent {
               questionsRange={range(1, 10)}
               questions={this.getQuestions(range(1, 10))}
               activeId={activeId}
-              back="1"
+              previous="/"
+              dataPath="static-data/NGC_188_data.json"
             />
-            <MakingHRD id="2" scrollable={0} />
-            <ComparingHRD id="3" scrollable={-1} />
+            <MakingHRD
+              id="2"
+              scrollable={0}
+              dataPath="static-data/NGC_188_data.json"
+              activeId="14"
+              questionsRange={[14]}
+              questions={this.getQuestions([14])}
+            />
+            <ComparingHRD
+              id="3"
+              scrollable={-1}
+              dataPath="static-data/NGC_188_data.json"
+              activeId="14"
+            />
             {/*            <HRDObservations
               id="4"
               scrollable={0}
@@ -75,10 +88,11 @@ class Sections extends React.PureComponent {
               activeId={activeId}
             /> */}
             <Results
-              id="5"
+              id="4"
               questions={questions}
               answers={answers}
               handleFinish={this.onFinish}
+              order={[1, 2, 3, 4, 5, 6, 7, 8, 9, 14]}
             />
           </React.Fragment>
         ) : (

--- a/src/components/questions/Prompt.jsx
+++ b/src/components/questions/Prompt.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Prompts extends React.PureComponent {
+  render() {
+    const { label } = this.props;
+
+    return <p>{label}</p>;
+  }
+}
+
+Prompts.propTypes = {
+  label: PropTypes.string,
+};
+
+export default Prompts;

--- a/src/components/questions/Prompts.jsx
+++ b/src/components/questions/Prompts.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Prompt from './Prompt';
+
+class Prompts extends React.PureComponent {
+  render() {
+    const { questions } = this.props;
+
+    return (
+      <React.Fragment>
+        {questions.map(question => {
+          const { id, label } = question;
+
+          return <Prompt key={`question-prompt-${id}`} label={label} />;
+        })}
+      </React.Fragment>
+    );
+  }
+}
+
+Prompts.propTypes = {
+  questions: PropTypes.array,
+};
+
+export default Prompts;

--- a/src/components/scatter-plot/Lasso.jsx
+++ b/src/components/scatter-plot/Lasso.jsx
@@ -25,7 +25,8 @@ class Lasso extends React.Component {
       dragEndCallback,
     } = this.props;
     const $scatterplot = d3Select(lassoableEl.current);
-    const $allPoints = d3Select(lassoableEl.current).selectAll('rect');
+    const $allPoints = d3Select(lassoableEl.current).selectAll('.data-point');
+
     const $dragLine = d3Line();
 
     $scatterplot.call(
@@ -71,12 +72,14 @@ class Lasso extends React.Component {
             d3Event.on('end', () => {
               const $filtered = $allPoints.filter((nodeData, i, nodes) => {
                 const nodePos = [
-                  Math.floor(d3Select(nodes[i]).attr('x')),
-                  Math.floor(d3Select(nodes[i]).attr('y')),
+                  Math.floor(d3Select(nodes[i]).attr('cx')),
+                  Math.floor(d3Select(nodes[i]).attr('cy')),
                 ];
                 const classification = classifyPoint(d, nodePos);
+
                 return classification === -1 || classification === 0;
               });
+
               $active.attr('d', $dragLine.curve(d3CurveCardinalClosed));
 
               this.setState(

--- a/src/components/scatter-plot/Points.jsx
+++ b/src/components/scatter-plot/Points.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import includes from 'lodash/includes';
+import Point from './Point.jsx';
+
+class Points extends React.PureComponent {
+  render() {
+    const { selectedData, hoveredData, filterBy } = this.props;
+    let { data } = this.props;
+
+    if (!data) {
+      return null;
+    }
+
+    if (!Array.isArray(data)) {
+      data = [data];
+    }
+
+    return (
+      <g className="data-points">
+        {data.map((d, i) => {
+          const key = `point-${i}`;
+          const selected = d === selectedData || includes(selectedData, d);
+          const hovered = d === hoveredData;
+
+          if (filterBy && !d[filterBy]) {
+            return null;
+          }
+
+          return (
+            <Point
+              key={key}
+              data={d}
+              selected={selected}
+              hovered={hovered}
+              tabIndex="0"
+            />
+          );
+        })}
+      </g>
+    );
+  }
+}
+
+Points.propTypes = {
+  data: PropTypes.array,
+  selectedData: PropTypes.bool,
+  hoveredData: PropTypes.bool,
+  filterBy: PropTypes.string,
+};
+
+export default Points;

--- a/src/components/star-selector/Point.jsx
+++ b/src/components/star-selector/Point.jsx
@@ -15,12 +15,10 @@ class Point extends React.PureComponent {
   }
 
   componentDidUpdate() {
-    const { selected, hovered } = this.props;
+    const { selected } = this.props;
     const $point = d3Select(this.el.current);
     if (selected) {
       this.selectStyle($point);
-    } else if (hovered) {
-      this.hoverStyle($point);
     } else {
       this.defaultStyle($point);
     }
@@ -30,20 +28,15 @@ class Point extends React.PureComponent {
     $point
       .transition()
       .duration(200)
-      .attr('fill', 'yellow');
+      .attr('r', 1)
+      .attr('fill', 'transparent');
   }
 
   selectStyle($point) {
     $point
       .transition()
       .duration(200)
-      .attr('fill', 'lightsteelblue');
-  }
-
-  hoverStyle($point) {
-    $point
-      .transition()
-      .duration(200)
+      .attr('r', 2)
       .attr('fill', 'red');
   }
 
@@ -56,9 +49,7 @@ class Point extends React.PureComponent {
         r={0}
         height={0}
         width={0}
-        strokeWidth={1}
         fill="transparent"
-        stroke="transparent"
         ref={this.el}
       />
     );
@@ -67,7 +58,6 @@ class Point extends React.PureComponent {
 
 Point.propTypes = {
   selected: PropTypes.bool,
-  hovered: PropTypes.bool,
 };
 
 export default Point;

--- a/src/components/star-selector/Points.jsx
+++ b/src/components/star-selector/Points.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import includes from 'lodash/includes';
+import Point from './Point.jsx';
+
+class Points extends React.PureComponent {
+  render() {
+    const { selectedData, filterBy } = this.props;
+    let { data } = this.props;
+
+    if (!data) {
+      return null;
+    }
+
+    if (!Array.isArray(data)) {
+      data = [data];
+    }
+
+    return (
+      <g className="data-points">
+        {data.map((d, i) => {
+          const key = `point-${i}`;
+          const selected = d === selectedData || includes(selectedData, d);
+
+          if (filterBy && !d[filterBy]) {
+            return null;
+          }
+
+          return <Point key={key} data={d} selected={selected} tabIndex="0" />;
+        })}
+      </g>
+    );
+  }
+}
+
+Points.propTypes = {
+  data: PropTypes.array,
+  selectedData: PropTypes.bool,
+  filterBy: PropTypes.string,
+};
+
+export default Points;

--- a/src/components/star-selector/index.jsx
+++ b/src/components/star-selector/index.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import includes from 'lodash/includes';
 import { select as d3Select, event as d3Event } from 'd3-selection';
 import { easeCircle as d3EaseCircle } from 'd3-ease';
 import { scaleLinear as d3ScaleLinear } from 'd3-scale';
 import 'd3-transition';
-import Point from '../scatter-plot/Point.jsx';
+import Points from './Points.jsx';
 import Lasso from '../scatter-plot/Lasso.jsx';
 
 class StarSelector extends React.Component {
@@ -19,16 +18,14 @@ class StarSelector extends React.Component {
     super(props);
 
     this.state = {
-      selectedData: null,
-      hoverPointData: null,
       showLasso: false,
       dragLine: [],
       dragLoop: [],
       xScale: d3ScaleLinear()
-        .domain([200, 0])
+        .domain(props.xDomain)
         .range([props.padding, props.width]),
       yScale: d3ScaleLinear()
-        .domain([0, 200])
+        .domain(props.yDomain)
         .range([props.height - props.padding, 0]),
     };
 
@@ -37,14 +34,11 @@ class StarSelector extends React.Component {
 
   componentDidMount() {
     this.updateScatterPlot();
-    console.log('component did mount');
+    // console.log('component did mount');
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const { selectedData, hoverPointData } = this.state;
-    const { data, dataSelectionCallback, clearOnChange } = this.props;
-    const differentSelectedData = selectedData !== prevState.selectedData;
-    const shouldCallback = dataSelectionCallback && differentSelectedData;
+  componentDidUpdate(prevProps) {
+    const { data, clearOnChange } = this.props;
 
     if (prevProps.data !== data) {
       this.updateScatterPlot();
@@ -54,83 +48,29 @@ class StarSelector extends React.Component {
     //   this.updatePoints();
     // }
 
-    if (shouldCallback) {
-      dataSelectionCallback(selectedData);
-    }
-
     /* eslint-disable react/no-did-update-set-state */
-    if (clearOnChange !== prevProps.clearOnChange && !hoverPointData) {
-      this.setState(currentState => ({
-        ...currentState,
-        hoverPointData: null,
-        selectedData: null,
-      }));
+    if (clearOnChange !== prevProps.clearOnChange) {
+      const { dataLassoCallback } = this.props;
+
+      if (dataLassoCallback) {
+        dataLassoCallback([]);
+      }
     }
     /* eslint-enable react/no-did-update-set-state */
   }
-
-  // mouseover/focus handler for point
-  onMouseOver = d => {
-    // add hover style on point
-    this.setState(prevState => ({
-      ...prevState,
-      hoverPointData: d,
-    }));
-  };
-
-  // mouseout/blur handler for point
-  onMouseOut = () => {
-    const { selectedData } = this.state;
-    const selectedPointId =
-      selectedData && !Array.isArray(selectedData) ? selectedData.id : null;
-
-    // remove hover style on point
-    if (selectedPointId) {
-      this.setState(prevState => ({
-        ...prevState,
-        hoverPointData: null,
-      }));
-      // remove hover style on poin
-    } else {
-      this.setState(prevState => ({
-        ...prevState,
-        hoverPointData: null,
-      }));
-    }
-  };
-
-  // point click handler
-  onClick = d => {
-    const { selectedData } = this.state;
-    const selectedPointId =
-      selectedData && !Array.isArray(selectedData) ? selectedData.id : null;
-
-    // remove selected style on point
-    if (d.id === selectedPointId) {
-      this.setState(prevState => ({
-        ...prevState,
-        selectedData: null,
-        showLasso: false,
-      }));
-      // add selected style on point
-    } else {
-      this.setState(prevState => ({
-        ...prevState,
-        selectedData: d,
-        showLasso: false,
-      }));
-    }
-  };
 
   onDragStart = () => {
     this.setState(
       prevState => ({
         ...prevState,
-        selectedData: [],
         showLasso: false,
       }),
       () => {
-        console.log('start');
+        const { dataLassoCallback } = this.props;
+
+        if (dataLassoCallback) {
+          dataLassoCallback([]);
+        }
       }
     );
   };
@@ -150,76 +90,37 @@ class StarSelector extends React.Component {
   onDragEnd = d => {
     const { dataLassoCallback } = this.props;
 
-    this.setState(
-      prevState => ({
-        ...prevState,
-        selectedData: d,
-      }),
-      () => {
-        const { selectedData } = this.state;
-
-        console.log('end');
-        dataLassoCallback(selectedData);
-      }
-    );
+    if (dataLassoCallback) {
+      dataLassoCallback(d);
+    }
   };
 
   // add event listeners to Scatterplot and Points
   addEventListeners() {
     const $scatterplot = d3Select(this.svgEl.current);
-    const $allPoints = d3Select(this.svgEl.current).selectAll('.data-point');
+    // const $allPoints = d3Select(this.svgEl.current).selectAll('.data-point');
 
     $scatterplot.on('click', () => {
       // remove styles and selections when click on non-point
       if (d3Event.target.classList[0] !== 'data-point') {
-        this.setState(prevState => ({
-          ...prevState,
-          hoverPointData: null,
-          selectedData: null,
-        }));
+        const { dataLassoCallback } = this.props;
+
+        if (dataLassoCallback) {
+          dataLassoCallback([]);
+        }
       }
-    });
-
-    // add event listeners to points
-    $allPoints
-      .on('mouseover focus', this.onMouseOver)
-      .on('mouseout blur', this.onMouseOut)
-      .on('click', this.onClick);
-  }
-
-  // render Point components
-  points() {
-    const { selectedData, hoverPointData } = this.state;
-    let { data } = this.props;
-
-    if (!data) {
-      return null;
-    }
-
-    if (!Array.isArray(data)) {
-      data = [data];
-    }
-
-    return data.map((d, i) => {
-      const key = `point-${i}`;
-      const selected = d === selectedData || includes(selectedData, d);
-      const hovered = d === hoverPointData;
-
-      return (
-        <Point
-          key={key}
-          data={d}
-          selected={selected}
-          hovered={hovered}
-          tabIndex="0"
-        />
-      );
     });
   }
 
   // add attributes to points
   updatePoints() {
-    const { data, xValueAccessor, yValueAccessor } = this.props;
+    const {
+      data,
+      xValueAccessor,
+      yValueAccessor,
+      filterBy,
+      preSelected,
+    } = this.props;
     const { xScale, yScale } = this.state;
 
     if (!data) {
@@ -228,7 +129,12 @@ class StarSelector extends React.Component {
 
     const $allPoints = d3Select(this.svgEl.current)
       .selectAll('.data-point')
-      .data(data);
+      .data(data)
+      .filter(nodeData => {
+        return filterBy ? nodeData[filterBy] : true;
+      });
+
+    // console.log($allPoints.data());
 
     $allPoints
       .attr('cx', d => {
@@ -240,19 +146,31 @@ class StarSelector extends React.Component {
       .transition()
       .duration(1000)
       .ease(d3EaseCircle)
-      .attr('r', 4)
-      .attr('fill', 'yellow');
+      .attr('r', preSelected ? 2 : 1)
+      .attr('fill', preSelected ? 'red' : 'transparent');
   }
 
   // bind data to elements and add styles and attributes
   updateScatterPlot() {
+    const { preSelected } = this.props;
     this.updatePoints();
-    this.addEventListeners();
+
+    if (!preSelected) {
+      this.addEventListeners();
+    }
   }
 
   render() {
     const { showLasso } = this.state;
-    const { width, height, backgroundImage } = this.props;
+    const {
+      data,
+      width,
+      height,
+      backgroundImage,
+      filterBy,
+      preSelected,
+      selection,
+    } = this.props;
 
     return (
       <div>
@@ -267,14 +185,16 @@ class StarSelector extends React.Component {
               backgroundImage: `url(${backgroundImage})`,
             }}
           >
-            <g className="data-points">{this.points()}</g>
-            <Lasso
-              active={showLasso}
-              lassoableEl={this.svgEl}
-              dragCallback={this.onDrag}
-              dragStartCallback={this.onDragStart}
-              dragEndCallback={this.onDragEnd}
-            />
+            <Points data={data} selectedData={selection} filterBy={filterBy} />
+            {!preSelected && (
+              <Lasso
+                active={showLasso}
+                lassoableEl={this.svgEl}
+                dragCallback={this.onDrag}
+                dragStartCallback={this.onDragStart}
+                dragEndCallback={this.onDragEnd}
+              />
+            )}
           </svg>
         </div>
       </div>
@@ -289,10 +209,14 @@ StarSelector.propTypes = {
   data: PropTypes.array,
   xValueAccessor: PropTypes.string,
   yValueAccessor: PropTypes.string,
+  xDomain: PropTypes.array,
+  yDomain: PropTypes.array,
   dataLassoCallback: PropTypes.func,
-  dataSelectionCallback: PropTypes.func,
   clearOnChange: PropTypes.bool,
   backgroundImage: PropTypes.any,
+  filterBy: PropTypes.string,
+  preSelected: PropTypes.bool,
+  selection: PropTypes.array,
 };
 
 export default StarSelector;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,8 +11,11 @@ const emptyState = {
   answers: {},
   activeId: null,
   activeGraphData: null,
+  clusterA: [],
+  clusterB: [],
 };
 
+// const existingState = emptyState;
 const existingState = ls('hrd') || emptyState;
 
 setGlobal(existingState);

--- a/static-data/questions.json
+++ b/static-data/questions.json
@@ -102,5 +102,13 @@
     "placeholder": null,
     "answerAccessor": "count",
     "answerPre": null
+  },
+  "14": {
+    "id": "14",
+    "type": "prompt",
+    "label": "Draw a circle around a group of stars to plot them on the H-R Diagram",
+    "placeholder": null,
+    "answerAccessor": "data",
+    "answerPre": "H-R Diagram created from user selected star cluster"
   }
 }


### PR DESCRIPTION
Store data selections as answers in global state
Store selection prompts as questions in global state
Scatterplot and Star Selector variants for preselected, filtered, and
non-interactive
Update Results page to accept new "graph" style QA


