### PR TITLE
Improve global store, and handle combined vs combining view render

### DIFF
--- a/src/GlobalStore.jsx
+++ b/src/GlobalStore.jsx
@@ -1,0 +1,78 @@
+import { addCallback, addReducer, setGlobal } from 'reactn';
+import ls from 'local-storage';
+import includes from 'lodash/includes';
+import sortBy from 'lodash/sortBy';
+
+class GlobalStore {
+  constructor() {
+    this.emptyState = {
+      lastUpdated: Date.now().toString(),
+      questions: null,
+      answers: {},
+      totalNumPages: 18,
+      visitedPages: [],
+      investigationProgress: 0,
+      pageProgress: 0,
+      activeId: null,
+      activeGraphData: null,
+      clusterA: [],
+      clusterB: [],
+    };
+
+    // const existingState = this.emptyState;
+    const existingState = ls('hrd') || this.emptyState;
+
+    setGlobal(existingState);
+  }
+
+  addCallbacks() {
+    addCallback(global => {
+      ls('hrd', global);
+      return null;
+    });
+  }
+
+  addReducers() {
+    addReducer('empty', prevGlobal => {
+      const global = {
+        ...prevGlobal,
+        lastUpdated: Date.now().toString(),
+        answers: {},
+        activeId: null,
+        activeGraphData: null,
+        visitedPages: [],
+        investigationProgress: 0,
+        pageProgress: 0,
+      };
+
+      ls('hrd', global);
+
+      return global;
+    });
+
+    addReducer('updateProgress', (prevGlobal, dispatch, currentProgress) => {
+      const { visitedPages: prevVisitedPages, totalNumPages } = prevGlobal;
+      const pageProgress = Math.ceil(
+        (currentProgress / (totalNumPages - 1)) * 100
+      );
+
+      const global = {
+        ...prevGlobal,
+        pageProgress,
+      };
+
+      if (!includes(prevVisitedPages, currentProgress)) {
+        const visitedPages = sortBy(prevVisitedPages.concat([currentProgress]));
+        const investigationProgress = Math.ceil(
+          (visitedPages.length / totalNumPages) * 100
+        );
+        global.visitedPages = visitedPages;
+        global.investigationProgress = investigationProgress;
+      }
+
+      return global;
+    });
+  }
+}
+
+export default GlobalStore;

--- a/src/GlobalStore.jsx
+++ b/src/GlobalStore.jsx
@@ -55,17 +55,19 @@ class GlobalStore {
       const pageProgress = Math.ceil(
         (currentProgress / (totalNumPages - 1)) * 100
       );
-
       const global = {
         ...prevGlobal,
         pageProgress,
       };
 
       if (!includes(prevVisitedPages, currentProgress)) {
-        const visitedPages = sortBy(prevVisitedPages.concat([currentProgress]));
+        const visitedPages = !prevVisitedPages
+          ? [currentProgress]
+          : sortBy(prevVisitedPages.concat([currentProgress]));
         const investigationProgress = Math.ceil(
           (visitedPages.length / totalNumPages) * 100
         );
+
         global.visitedPages = visitedPages;
         global.investigationProgress = investigationProgress;
       }

--- a/src/components/content/containers/ProgressContainer.jsx
+++ b/src/components/content/containers/ProgressContainer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 import reactn from 'reactn';
 import PropTypes from 'prop-types';
-import isNumber from 'lodash/isNumber';
+import _isFinite from 'lodash/isFinite';
 
 @reactn
 class ProgressContainer extends React.Component {
@@ -22,7 +22,7 @@ class ProgressContainer extends React.Component {
     const splitted = progress.split('/');
     const id = parseInt(splitted[splitted.length - 1], 10);
 
-    if (isNumber(id)) {
+    if (_isFinite(id)) {
       return id;
     }
 

--- a/src/components/content/sections/index.jsx
+++ b/src/components/content/sections/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import reactn from 'reactn';
 import { Switch, Route } from 'react-router-dom';
-import includes from 'lodash/includes';
 import isEmpty from 'lodash/isEmpty';
 import range from 'lodash/range';
 import API from '../../site/API';
@@ -67,6 +66,19 @@ class Sections extends React.PureComponent {
         {capitalize(type)} (<StellarUnit type={type} isSvg />)
       </tspan>
     );
+  }
+
+  visitedFarther(visitedPages, targetPage) {
+    let i = visitedPages.length;
+    let isFarther = false;
+
+    while (i >= 0 && !isFarther) {
+      isFarther = visitedPages[i] > targetPage;
+
+      i -= 1;
+    }
+
+    return isFarther;
   }
 
   render() {
@@ -250,7 +262,7 @@ class Sections extends React.PureComponent {
               path="/9"
               render={() => (
                 <React.Fragment>
-                  {includes(visitedPages, 9) ? (
+                  {this.visitedFarther(visitedPages, 9) ? (
                     <CombinedHRD
                       id="9"
                       next="/progress/9"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,13 +1,10 @@
-import React, { addCallback, addReducer, setGlobal } from 'reactn';
+import React from 'reactn';
 import ReactDOM from 'react-dom';
-import ls from 'local-storage';
-import includes from 'lodash/includes';
-import sortBy from 'lodash/sortBy';
 import App from './App.jsx';
+import GlobalStore from './GlobalStore.jsx';
 import './assets/stylesheets/styles.scss';
 
-// Set an Initial global state
-const emptyState = {
+const empty = {
   lastUpdated: Date.now().toString(),
   questions: null,
   answers: {},
@@ -21,51 +18,10 @@ const emptyState = {
   clusterB: [],
 };
 
-// const existingState = emptyState;
-const existingState = ls('hrd') || emptyState;
+const store = new GlobalStore(empty);
 
-setGlobal(existingState);
-
-// Maybe a bit heavy handed?  Better to tie this LocalStorage Update to the route/section changes...?
-addCallback(global => {
-  ls('hrd', global);
-  return null;
-});
-
-addReducer('empty', prevGlobal => {
-  const global = {
-    ...prevGlobal,
-    answers: {},
-    activeId: null,
-    activeGraphData: null,
-  };
-
-  ls('hrd', global);
-
-  return global;
-});
-
-addReducer('updateProgress', (prevGlobal, dispatch, currentProgress) => {
-  const { visitedPages: prevVisitedPages, totalNumPages } = prevGlobal;
-  const pageProgress = Math.ceil((currentProgress / (totalNumPages - 1)) * 100);
-
-  const global = {
-    ...prevGlobal,
-    pageProgress,
-  };
-
-  if (!includes(prevVisitedPages, currentProgress)) {
-    const visitedPages = sortBy(prevVisitedPages.concat([currentProgress]));
-    const investigationProgress = Math.ceil(
-      (visitedPages.length / totalNumPages) * 100
-    );
-
-    global.visitedPages = visitedPages;
-    global.investigationProgress = investigationProgress;
-  }
-
-  return global;
-});
+store.addCallbacks();
+store.addReducers();
 
 if (process.env.NODE_ENV !== 'production') {
   const Axe = require('react-axe'); // eslint-disable-line global-require


### PR DESCRIPTION
Was not using the available global state correctly.

Now, given the way the global state behaves, uses the appropriate values to determine if visited vs not-visited page should load which view.