### PR TITLE
[EPO-2073] Increase interactive-able area for Bars

### DIFF
--- a/src/assets/stylesheets/components/charts/_bar.scss
+++ b/src/assets/stylesheets/components/charts/_bar.scss
@@ -1,3 +1,12 @@
+.data-bar-wrapper {
+  cursor: pointer;
+  transition: fill $durationSlow $timing;
+
+  &:focus {
+    outline: none;
+  }
+}
+
 .data-bar {
   cursor: pointer;
   transition: fill $durationSlow $timing;

--- a/src/assets/stylesheets/components/charts/_histogram.scss
+++ b/src/assets/stylesheets/components/charts/_histogram.scss
@@ -1,14 +1,26 @@
 .histogram {
-  .data-bar {
-    fill: $baseSecondaryLight;
-    stroke: $black;
+  .data-bar-wrapper {
+    .data-bar {
+      fill: $baseSecondaryLight;
+      stroke: $black;
+    }
+
+    &.hovered, &.selected {
+      .data-bar-diff {
+        fill: $neutral10;
+      }
+    }
 
     &.hovered {
-      fill: $baseSecondary;
+      .data-bar {
+        fill: $baseSecondary;
+      }
     }
 
     &.selected {
-      fill: $baseSecondaryDark;
+      .data-bar {
+        fill: $baseSecondaryDark;
+      }
     }
   }
 

--- a/src/components/histogram/Bar.jsx
+++ b/src/components/histogram/Bar.jsx
@@ -4,23 +4,57 @@ import classnames from 'classnames';
 
 class Bar extends React.PureComponent {
   render() {
-    const { x, y, width, height, selected, hovered, classes } = this.props;
-    const barClasses = classnames(`data-bar ${classes}`, {
+    const {
+      x,
+      y,
+      absentY,
+      width,
+      height,
+      absentHeight,
+      selected,
+      hovered,
+      classes,
+    } = this.props;
+    // const barClasses = classnames(`data-bar-wrapper ${classes || ""}`, {
+    //   selected,
+    //   hovered,
+    // });
+
+    const barWrapperClasses = classnames('data-bar-wrapper', {
       selected,
       hovered,
     });
 
     return (
-      <rect
-        className={barClasses}
-        x={x}
-        y={y}
-        height={height}
-        width={width}
-        strokeWidth={1}
-        fill="transparent"
-        stroke="transparent"
-      />
+      <g className={barWrapperClasses}>
+        <rect
+          className="data-bar"
+          x={x}
+          y={y}
+          height={height}
+          width={width}
+          strokeWidth={1}
+          fill="transparent"
+        />
+        <rect
+          className={`data-bar-diff ${classes || ''}`}
+          x={x}
+          y={absentY}
+          height={absentHeight}
+          width={width}
+          fill="transparent"
+          stroke="transparent"
+        />
+        <rect
+          className="data-bar-data"
+          x={x}
+          y={absentY}
+          height={absentHeight + height + 1}
+          width={width}
+          fill="transparent"
+          stroke="transparent"
+        />
+      </g>
     );
   }
 }
@@ -30,8 +64,10 @@ Bar.propTypes = {
   hovered: PropTypes.bool,
   x: PropTypes.number,
   y: PropTypes.number,
+  absentY: PropTypes.number,
   width: PropTypes.number,
   height: PropTypes.number,
+  absentHeight: PropTypes.number,
   classes: PropTypes.string,
 };
 

--- a/src/components/histogram/Bars.jsx
+++ b/src/components/histogram/Bars.jsx
@@ -17,21 +17,25 @@ class Bars extends React.PureComponent {
       xScale,
       yScale,
       offsetTop,
+      graphHeight,
+      padding,
       barClasses,
     } = this.props;
-
     return (
       <g className="data-bars">
         {data.map((d, i) => {
           const key = `bar-${i}`;
+          const barHeight = yScale(0) - yScale(d.length);
 
           return (
             <Bar
               key={key}
               x={xScale(d.x0)}
               y={yScale(d.length) + offsetTop}
+              absentY={offsetTop}
               width={xScale(d.x1) - xScale(d.x0)}
-              height={yScale(0) - yScale(d.length)}
+              height={barHeight}
+              absentHeight={graphHeight - padding - barHeight - 1}
               classes={barClasses}
               selected={this.isMatch(selectedData, d)}
               hovered={this.isMatch(hoveredData, d)}
@@ -48,6 +52,8 @@ Bars.propTypes = {
   selectedData: PropTypes.bool,
   hoveredData: PropTypes.bool,
   offsetTop: PropTypes.number,
+  graphHeight: PropTypes.number,
+  padding: PropTypes.number,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
   barClasses: PropTypes.string,

--- a/src/components/histogram/index.jsx
+++ b/src/components/histogram/index.jsx
@@ -133,13 +133,13 @@ class Histogram extends React.PureComponent {
         .thresholds(d3ThresholdScott)(data);
     }
 
-    if (valueAccessor === 'radius') {
-      return d3Histogram()
-        .value(d => {
-          return d[valueAccessor]; // eslint-disable-line dot-notation
-        })
-        .thresholds(15)(data);
-    }
+    // if (valueAccessor === 'radius') {
+    //   return d3Histogram()
+    //     .value(d => {
+    //       return d[valueAccessor]; // eslint-disable-line dot-notation
+    //     })
+    //     .thresholds(10)(data);
+    // }
 
     if (domain) {
       return d3Histogram()
@@ -260,7 +260,7 @@ class Histogram extends React.PureComponent {
   // add event listeners to Histogram and Bars
   addEventListeners() {
     const $histogram = d3Select(this.svgEl.current);
-    const $bars = d3Select(this.svgEl.current).selectAll('.data-bar');
+    const $bars = d3Select(this.svgEl.current).selectAll('.data-bar-data');
 
     $histogram.on('click', () => {
       // remove styles and selections when click on non-bar
@@ -283,7 +283,7 @@ class Histogram extends React.PureComponent {
     const $histogram = d3Select(this.svgEl.current);
 
     $histogram
-      .selectAll('.data-bar')
+      .selectAll('.data-bar-data')
       .data(data)
       .transition()
       .end()
@@ -369,6 +369,8 @@ class Histogram extends React.PureComponent {
                 offsetTop={offsetTop}
                 xScale={xScale}
                 yScale={yScale}
+                graphHeight={height}
+                padding={padding}
               />
               {meanData && valueAccessor && (
                 <MeanBar


### PR DESCRIPTION
In the histogram, each columnar area each bar is situated in now represents the clickable/hoverable area (instead of only being able to interact with the bar itself). This alleviates my main concern with the histogram binning: bins so small you can't click on them. 

